### PR TITLE
Add ESLint error troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # reestri_connector
+
+This repository contains an experimental connector for interacting with external registries. It uses Cloud Functions written in TypeScript along with a small React dashboard.
+
+## Troubleshooting
+
+If ESLint fails with an error like:
+
+```
+TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions': Cannot read properties of undefined
+```
+
+Ensure that your ESLint configuration sets `parserOptions.project` to point to a valid `tsconfig.json`. Some `@typescript-eslint` rules require type information from the parser, and they will crash if the project option is missing. Updating `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to matching versions may also help.


### PR DESCRIPTION
## Summary
- expand README with troubleshooting steps for `@typescript-eslint/no-unused-expressions`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68701b45be3083319225f90e027e3686

## Summary by Sourcery

Documentation:
- Add a "Troubleshooting" section to README with steps to resolve the '@typescript-eslint/no-unused-expressions' rule error