### PR TITLE
Fix missing ESLint plugin

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -27,6 +27,8 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "@typescript-eslint/eslint-plugin": "^8.36.0",
+    "@typescript-eslint/parser": "^8.36.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
## Summary
- add `@typescript-eslint/eslint-plugin` and parser to Cloud Functions dev deps

## Testing
- `pnpm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.13.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68701d1e9790833187d3246dc7aff984

## Summary by Sourcery

Bug Fixes:
- Add @typescript-eslint/eslint-plugin and parser to the functions package.json devDependencies